### PR TITLE
Empty interface name (Windows 7), 

### DIFF
--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -265,7 +265,7 @@ sub _get_win32_interface_info {
             next;
         } elsif ( $line =~/^\s$/ ) {
             next;
-        } elsif ( ( $line =~ $regexes{'address'} ) and $interface ) {
+        } elsif ( ( $line =~ $regexes{'address'} ) and defined $interface ) {
             $if_info{$interface} = $1;
             $interface = undef;
         } elsif ( $line =~ $regexes{'adapter'} ) {

--- a/t/data/ipconfig-win10.txt
+++ b/t/data/ipconfig-win10.txt
@@ -1,0 +1,16 @@
+
+Windows IP Configuration
+
+
+Ethernet adapter Ethernet 2:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : 
+
+Ethernet adapter Ethernet:
+
+   Connection-specific DNS Suffix  . : example.org
+   Link-local IPv6 Address . . . . . : fe80::2927:d4e6:18b4:432%2
+   IPv4 Address. . . . . . . . . . . : 192.168.1.100
+   Subnet Mask . . . . . . . . . . . : 255.255.0.0
+   Default Gateway . . . . . . . . . : 192.168.1.1

--- a/t/data/ipconfig-win7-empty-name.txt
+++ b/t/data/ipconfig-win7-empty-name.txt
@@ -1,0 +1,28 @@
+
+Windows IP Configuration
+
+
+Ethernet adapter Local Area Connection 3:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : 
+   Link-local IPv6 Address . . . . . : fe80::1d6c:95:b3d7:8b4c%20
+   Default Gateway . . . . . . . . . : 
+
+Ethernet adapter :
+
+   Connection-specific DNS Suffix  . : example.org
+   Link-local IPv6 Address . . . . . : fe80::9437:94dc:5211:414c%16
+   IPv4 Address. . . . . . . . . . . : 192.168.1.101
+   Subnet Mask . . . . . . . . . . . : 255.255.0.0
+   Default Gateway . . . . . . . . . : 192.168.1.1
+
+Tunnel adapter isatap.{1212A406-F319-4841-B7DC-7B919C7BE3D9}:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : 
+
+Tunnel adapter isatap.example.org:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : example.org

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 4;
+use Test::More tests => 2 * 5;
 
 use File::Spec;
 use Sys::HostIP;
@@ -66,4 +66,12 @@ mock_and_test(
         '' => '192.168.1.101',
     },
     'Win7 interface, empty name',
+    );
+
+mock_and_test(
+    'ipconfig-win10.txt',
+    {
+        'Ethernet' => '192.168.1.100',
+    },
+    'Correct Win10 interface',
     );

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 3;
+use Test::More tests => 2 * 4;
 
 use File::Spec;
 use Sys::HostIP;
@@ -60,3 +60,10 @@ mock_and_test(
     'Correct Win7 interface',
 );
 
+mock_and_test(
+    'ipconfig-win7-empty-name.txt',
+    {
+        '' => '192.168.1.101',
+    },
+    'Win7 interface, empty name',
+    );


### PR DESCRIPTION
Today I discovered an empty interface name on a Windows 7 installation that had been booted via iSCSI. This PR adds a test case for this plus a small fix.

I have also added a Windows 10 testcase.