### PR TITLE
Restore missing NAME section to POD

### DIFF
--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -281,6 +281,10 @@ sub _get_win32_interface_info {
 
 __END__
 
+=head1 NAME
+
+Sys::HostIP - Try extra hard to get IP address related info
+
 =head1 SYNOPSIS
 
     use Sys::HostIP;


### PR DESCRIPTION
When converting POD to manpage content, the "NAME" section is parsed by lexgrog and used to generate a database that's queried by commands like apropos and whatis.
