### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: true
+
+language: perl
+
+perl:
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - sudo apt-get install net-tools
+    - dzil authordeps --missing | cpanm  --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
This is an initial Travis-CI config which tests the dist on Perls 5.10 .. 5.24 on Ubuntu (the default image used by the Travis-CI infrastructure).  The `net-tools` OS package has to be installed explicitly so that `ifconfig` is available and the tests can run correctly.

This PR is submitted in the hope that it is helpful.  If you have any questions or comments, please don't hesitate to contact me!