### PR TITLE
Add copyright and license info to docs and README

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -105,6 +105,15 @@ I haven't tested the win32 code with dialup or wireless connections.
 
 Machines with output in different languages (German, for example) fail.
 
+# COPYRIGHT AND LICENSE
+
+Copyright (C) prior to 2010, Jonathan Schatz <bluelines@divisionbyzero.com>.
+
+Copyright (C) 2010-2016, Sawyer X <xsawyerx@cpan.org>.
+
+This program is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
 # SEE ALSO
 
 - ifconfig(8)

--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -392,6 +392,15 @@ I haven't tested the win32 code with dialup or wireless connections.
 
 Machines with output in different languages (German, for example) fail.
 
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) prior to 2010, Jonathan Schatz <bluelines@divisionbyzero.com>.
+
+Copyright (C) 2010-2016, Sawyer X <xsawyerx@cpan.org>.
+
+This program is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
 =head1 SEE ALSO
 
 =over 4


### PR DESCRIPTION
This PR corrects the has_license_in_source_file core issue mentioned on the [CPANTS page for this dist](http://cpants.cpanauthors.org/dist/Sys-HostIP).  It will also correct the has_known_license_in_source_file CPANTS extra issue.

I've used the short version of the license text (without mentioning the LICENSE file), since the LICENSE isn't present in the repo and any users looking in the repo might be confused by the README mentioning a file which doesn't exist in the repo.  If you want me to add a text such as:

> For details, see the full text of the license in the file LICENSE.

just let me know and I'll update the PR.

I've used copyright dates from the git history, hence why I could only say that Jonathan Schatz' copyright was prior to 2010.  If this is incorrect or should be mentioned differently, just let me know and I'll update the PR as appropriate.

As usual, this PR is submitted in the hope that it is helpful.  If you have any questions or comments, please don't hesitate to contact me!