### PR TITLE
Declare all build prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -51,6 +51,8 @@ File::Basename = 0
 Test::More   = 0
 Data::Dumper = 0
 File::Spec   = 0
+Test::Pod    = 0
+Test::CPAN::Meta = 0
 
 [ ReadmeAnyFromPod / MarkdownInRoot ]
 filename = README.mkdn

--- a/dist.ini
+++ b/dist.ini
@@ -48,10 +48,10 @@ Exporter       = 0
 File::Basename = 0
 
 [Prereqs / TestRequires ]
-Test::More   = 0
-Data::Dumper = 0
-File::Spec   = 0
-Test::Pod    = 0
+Test::More       = 0
+Data::Dumper     = 0
+File::Spec       = 0
+Test::Pod        = 0
 Test::CPAN::Meta = 0
 
 [ ReadmeAnyFromPod / MarkdownInRoot ]


### PR DESCRIPTION
This PR resolves the CPANTS `build_prereq_matches_use` issue (see http://cpants.cpanauthors.org/dist/Sys-HostIP).  I've split this PR into two commits since the second change merely aligns the assignment operators and version numbers above each other in the standard fashion, and I didn't want to make the diffs confuse the real content changes with the formatting changes.  If you want, I could squash the commits and resubmit.