### PR TITLE
Declare minimum Perl version explicitly

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -43,6 +43,7 @@ repository.type = git
 match = dist.ini
 
 [Prereqs]
+perl           = 5.006
 Carp           = 0
 Exporter       = 0
 File::Basename = 0


### PR DESCRIPTION
... which resolves the `meta_yml_declares_perl_version` CPANTS issue.