### PR TITLE
Handle more locales on Windows systems

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -107,7 +107,9 @@ Currently maintained by Sawyer X <xsawyerx@cpan.org>.
 
 I haven't tested the win32 code with dialup or wireless connections.
 
-Machines with output in different languages (German, for example) fail.
+Machines with output in some languages other than English fail.
+Neverthless, the code has been shown to work in German, Swedish, French,
+Italian, and Finnish locales.
 
 # COPYRIGHT AND LICENSE
 

--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -248,7 +248,7 @@ sub _get_win32_interface_info {
 
         adapter => qr/
             ^
-            Ethernet (?:\s?|-) \w+
+            (?:Ethernet(?:\s?|-)\w+|\w+\s+Ethernet)
             \s+
             (.*) :
         /x,
@@ -271,6 +271,7 @@ sub _get_win32_interface_info {
         } elsif ( $line =~ $regexes{'adapter'} ) {
             $interface = $1;
             chomp $interface;
+            $interface =~ s/\s+$//g;  # remove trailing whitespace, if any
         }
     }
 

--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -241,14 +241,14 @@ sub _get_win32_interface_info {
     my %regexes = (
         address => qr/
             \s+
-            IP(?:v4)? \s Address .* :
+            IP(?:v4)? .*? :
             \s+
             (\d+ (?: \. \d+ ){3} )
         /x,
 
         adapter => qr/
             ^
-            Ethernet \s adapter
+            Ethernet (?:\s?|-) \w+
             \s+
             (.*) :
         /x,
@@ -260,7 +260,7 @@ sub _get_win32_interface_info {
     foreach my $line (@ipconfig) {
         chomp($line);
 
-        if ( $line =~/^Windows IP Configuration/ ) {
+        if ( $line =~ /Windows/ ) {
             # ignore the header
             next;
         } elsif ( $line =~/^\s$/ ) {

--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -395,7 +395,9 @@ Currently maintained by Sawyer X <xsawyerx@cpan.org>.
 
 I haven't tested the win32 code with dialup or wireless connections.
 
-Machines with output in different languages (German, for example) fail.
+Machines with output in some languages other than English fail.
+Neverthless, the code has been shown to work in German, Swedish, French,
+Italian, and Finnish locales.
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/t/data/ipconfig-win2008-sv_SE.txt
+++ b/t/data/ipconfig-win2008-sv_SE.txt
@@ -1,0 +1,21 @@
+
+IP-konfiguration f�r Windows
+
+
+Ethernet-anslutning Anslutning till lokalt n�tverk:
+
+    Anslutningsspecifika DNS-suffix . :
+    L�nklokal IPv6-adress . . . . . . : ff88::b6fa:c6e1:9a9a:9114%10
+    IPv4-adress . . . . . . . . . . . : 192.168.40.241
+    N�tmask . . . . . . . . . . . . . : 255.255.255.0
+    Standard-gateway. . . . . . . . . : 192.168.40.1
+
+Tunnelanslutning: Anslutning till lokalt n�tverk*:
+
+    Tillst�nd . . . . . . . . . . . . : Fr�nkopplad
+    Anslutningsspecifika DNS-suffix . :
+
+Tunnelanslutning: Anslutning till lokalt n�tverk* 8:
+
+    Tillst�nd . . . . . . . . . . . . : Fr�nkopplad
+    Anslutningsspecifika DNS-suffix . :

--- a/t/data/ipconfig-win7-de_DE.txt
+++ b/t/data/ipconfig-win7-de_DE.txt
@@ -1,0 +1,23 @@
+
+Windows-IP-Konfiguration
+
+
+Ethernet-Adapter LAN-Verbindung:
+
+   Verbindungsspezifisches DNS-Suffix:
+   Verbindungslokale IPv6-Adresse  . : fe80::417a:e1a3:e92e:76f2%11
+   IPv4-Adresse  . . . . . . . . . . : 10.0.2.15
+   Subnetzmaske  . . . . . . . . . . : 255.255.255.0
+   Standardgateway . . . . . . . . . : 10.0.2.2
+
+Tunneladapter isatap.{3505548F-914A-4E9F-B2A8-C05189D0D45C}:
+
+   Medienstatus. . . . . . . . . . . : Medium getrennt
+   Verbindungsspezifisches DNS-Suffix:
+
+Tunneladapter LAN-Verbindung*:
+
+   Verbindungsspezifisches DNS-Suffix:
+   IPv6-Adresse. . . . . . . . . . . : 2001:0:9d38:78cf:c3f:89fb:af44:9349
+   Verbindungslokale IPv6-Adresse  . : fe80::c3f:89fb:af44:9349%13
+   Standardgateway . . . . . . . . . : ::

--- a/t/data/ipconfig-win7-fi_FI.txt
+++ b/t/data/ipconfig-win7-fi_FI.txt
@@ -1,0 +1,39 @@
+
+Windows IP-m‰‰ritykset
+
+
+Ethernet-sovitin LAN-Verbindung:
+
+        Yhteyskohtainen DNS-liite . . . . : S_W_3V_1_3_0
+   IPv6-osoite . . . . . . . . . . . : 2003:e7:93ce:2801:71f4:f151:8100:f395
+   Tilap‰inen IPv6-osoite. . . . . . : 2003:e7:93ce:2801:2d03:317f:1567:19ee
+   Linkin paikallinen IPv6-osoite. . : fe80::71f4:f151:8100:f395%11
+   IPv4-osoite . . . . . . . . . . . : 192.168.2.118
+        Aliverkon peite . . . . . . . . . : 255.255.255.0
+        Oletusyhdysk‰yt‰v‰. . . . . . . . : fe80::1%11
+                                            192.168.2.1
+
+Ethernet-sovitin VirtualBox Host-Only Network:
+
+        Yhteyskohtainen DNS-liite . . . . :
+   Linkin paikallinen IPv6-osoite. . : fe80::a8fa:b31b:672b:b415%14
+   IPv4-osoite . . . . . . . . . . . : 192.168.56.1
+        Aliverkon peite . . . . . . . . . : 255.255.255.0
+        Oletusyhdysk‰yt‰v‰. . . . . . . . :
+
+Tunnelisovitin isatap.S_W_3V_1_3_0:
+
+        Laitteen tila . . . . . . . . . . : Ei kytketty
+        Yhteyskohtainen DNS-liite . . . . : S_W_3V_1_3_0
+
+Tunnelisovitin LAN-Verbindung* 3:
+
+        Yhteyskohtainen DNS-liite . . . . :
+   IPv6-osoite . . . . . . . . . . . : 2001:0:9d38:78cf:c02:3711:a4ee:a12d
+   Linkin paikallinen IPv6-osoite. . : fe80::c02:3711:a4ee:a12d%13
+        Oletusyhdysk‰yt‰v‰. . . . . . . . :
+
+Tunnelisovitin isatap.{2F276BC5-ADC1-4179-BFB7-161CEA6B8A27}:
+
+        Laitteen tila . . . . . . . . . . : Ei kytketty
+        Yhteyskohtainen DNS-liite . . . . :

--- a/t/data/ipconfig-win7-fr_FR.txt
+++ b/t/data/ipconfig-win7-fr_FR.txt
@@ -1,0 +1,40 @@
+
+Configuration IP de Windows
+
+
+Carte Ethernet LAN-Verbindung :
+
+   Suffixe DNS propre à la connexion. . . : S_W_23V_1_3_0
+   Adresse IPv6. . . . . . . . . . . . . .: 2003:e7:93ce:2801:71f4:f151:8100:f395
+   Adresse IPv6 temporaire . . . . . . . .: 2003:e7:93ce:2801:8dd:1829:d3ce:9915
+
+   Adresse IPv6 de liaison locale. . . . .: fe80::71f4:f151:8100:f395%11
+   Adresse IPv4. . . . . . . . . . . . . .: 192.168.2.118
+   Masque de sous-réseau. . . . . . . . . : 255.255.255.0
+   Passerelle par défaut. . . . . . . . . : fe80::1%11
+                                       192.168.2.1
+
+Carte Ethernet VirtualBox Host-Only Network :
+
+   Suffixe DNS propre à la connexion. . . :
+   Adresse IPv6 de liaison locale. . . . .: fe80::a8fa:b31b:672b:b415%14
+   Adresse IPv4. . . . . . . . . . . . . .: 192.168.56.1
+   Masque de sous-réseau. . . . . . . . . : 255.255.255.0
+   Passerelle par défaut. . . . . . . . . :
+
+Carte Tunnel isatap.S_W_23V_1_3_0 :
+
+   Statut du média. . . . . . . . . . . . : Média déconnecté
+   Suffixe DNS propre à la connexion. . . : S_W_23V_1_3_0
+
+Carte Tunnel LAN-Verbindung* 3 :
+
+   Suffixe DNS propre à la connexion. . . :
+   Adresse IPv6. . . . . . . . . . . . . .: 2001:0:9d38:78cf:c02:3711:a4ee:a12d
+   Adresse IPv6 de liaison locale. . . . .: fe80::c02:3711:a4ee:a12d%13
+   Passerelle par défaut. . . . . . . . . :
+
+Carte Tunnel isatap.{2F276BC5-ADC1-4179-BFB7-161CEA6B8A27} :
+
+   Statut du média. . . . . . . . . . . . : Média déconnecté
+   Suffixe DNS propre à la connexion. . . :

--- a/t/data/ipconfig-win7-it_IT.txt
+++ b/t/data/ipconfig-win7-it_IT.txt
@@ -1,0 +1,41 @@
+
+Configurazione IP di Windows
+
+
+Scheda Ethernet LAN-Verbindung:
+
+   Suffisso DNS specifico per connessione: S_W_3V_1_3_0
+   Indirizzo IPv6 . . . . . . . . . . . . . . . . . : 2003:e7:93ce:2801:71f4:f151:8100:f395
+   Indirizzo IPv6 temporaneo. . . . . . . . . . . . : 2003:e7:93ce:2801:dd3:a13a:4d7b:9b35
+   Indirizzo IPv6 locale rispetto al collegamento . : fe80::71f4:f151:8100:f395%11
+   Indirizzo IPv4. . . . . . . . . . . . : 192.168.2.118
+   Subnet mask . . . . . . . . . . . . . : 255.255.255.0
+   Gateway predefinito . . . . . . . . . : fe80::1%11
+                                           192.168.2.1
+
+Scheda Ethernet VirtualBox Host-Only Network:
+
+   Suffisso DNS specifico per connessione:
+   Indirizzo IPv6 locale rispetto al collegamento . : fe80::a8fa:b31b:672b:b415%14
+   Indirizzo IPv4. . . . . . . . . . . . : 192.168.56.1
+   Subnet mask . . . . . . . . . . . . . : 255.255.255.0
+   Gateway predefinito . . . . . . . . . :
+
+Scheda Tunnel isatap.S_W_3V_1_3_0:
+
+   Stato supporto. . . . . . . . . . . . : Supporto disconnesso
+   Suffisso DNS specifico per connessione: S_W_3V_1_3_0
+
+Scheda Tunnel LAN-Verbindung* 3:
+
+   Suffisso DNS specifico per connessione:
+   Indirizzo IPv6 . . . . . . . . . . . . . . . . . : 2001:0:9d38:78cf:c02:3711:
+a4ee:a12d
+   Indirizzo IPv6 locale rispetto al collegamento . : fe80::c02:3711:a4ee:a12d%1
+3
+   Gateway predefinito . . . . . . . . . :
+
+Scheda Tunnel isatap.{2F276BC5-ADC1-4179-BFB7-161CEA6B8A27}:
+
+   Stato supporto. . . . . . . . . . . . : Supporto disconnesso
+   Suffisso DNS specifico per connessione:

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 7;
+use Test::More tests => 2 * 8;
 
 use File::Spec;
 use Sys::HostIP;
@@ -90,4 +90,13 @@ mock_and_test(
         'LAN-Verbindung' => '10.0.2.15',
     },
     'Correct Windows 7 interface in German locale',
+    );
+
+mock_and_test(
+    'ipconfig-win7-fr_FR.txt',
+    {
+        'LAN-Verbindung' => '192.168.2.118',
+        'VirtualBox Host-Only Network' => '192.168.56.1',
+    },
+    'Correct Windows 7 interface in French locale',
     );

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 8;
+use Test::More tests => 2 * 9;
 
 use File::Spec;
 use Sys::HostIP;
@@ -99,4 +99,13 @@ mock_and_test(
         'VirtualBox Host-Only Network' => '192.168.56.1',
     },
     'Correct Windows 7 interface in French locale',
+    );
+
+mock_and_test(
+    'ipconfig-win7-it_IT.txt',
+    {
+        'LAN-Verbindung' => '192.168.2.118',
+        'VirtualBox Host-Only Network' => '192.168.56.1',
+    },
+    'Correct Windows 7 interface in Italian locale',
     );

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 5;
+use Test::More tests => 2 * 6;
 
 use File::Spec;
 use Sys::HostIP;
@@ -74,4 +74,12 @@ mock_and_test(
         'Ethernet' => '192.168.1.100',
     },
     'Correct Win10 interface',
+    );
+
+mock_and_test(
+    'ipconfig-win2008-sv_SE.txt',
+    {
+        'Anslutning till lokalt n�tverk' => '192.168.40.241',
+    },
+    'Correct Windows Server 2008 interface in Swedish locale',
     );

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 6;
+use Test::More tests => 2 * 7;
 
 use File::Spec;
 use Sys::HostIP;
@@ -82,4 +82,12 @@ mock_and_test(
         'Anslutning till lokalt n�tverk' => '192.168.40.241',
     },
     'Correct Windows Server 2008 interface in Swedish locale',
+    );
+
+mock_and_test(
+    'ipconfig-win7-de_DE.txt',
+    {
+        'LAN-Verbindung' => '10.0.2.15',
+    },
+    'Correct Windows 7 interface in German locale',
     );

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -32,8 +32,8 @@ sub mock_and_test {
     };
 
     is_deeply(
-        $expected_results,
         $hostip->_get_win32_interface_info,
+        $expected_results,
         $test_name,
     );
 

--- a/t/ipconfig.t
+++ b/t/ipconfig.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2 * 9;
+use Test::More tests => 2 * 10;
 
 use File::Spec;
 use Sys::HostIP;
@@ -108,4 +108,13 @@ mock_and_test(
         'VirtualBox Host-Only Network' => '192.168.56.1',
     },
     'Correct Windows 7 interface in Italian locale',
+    );
+
+mock_and_test(
+    'ipconfig-win7-fi_FI.txt',
+    {
+        'LAN-Verbindung' => '192.168.2.118',
+        'VirtualBox Host-Only Network' => '192.168.56.1',
+    },
+    'Correct Windows 7 interface in Finnish locale',
     );


### PR DESCRIPTION
These changes allow `Sys::HostIP` to handle Swedish and German locales on Windows systems.  Please see the commit messages for the gory details.  This PR should fix the issues raised in issue #7.