### PR TITLE
Fall back to 'ip' if 'ifconfig' isn't available

### DIFF
--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -109,7 +109,7 @@ sub _get_ifconfig_binary {
 
     ## no critic qw(Variables::ProhibitPunctuationVars)
     if ( $^O =~ /(?: linux|openbsd|freebsd|netbsd|solaris|darwin )/xmsi ) {
-        $ifconfig = '/sbin/ifconfig -a';
+        $ifconfig = -f '/sbin/ifconfig' ? '/sbin/ifconfig -a' : '/sbin/ip address';
     } elsif ( $^O eq 'aix' ) {
         $ifconfig = '/usr/sbin/ifconfig -a';
     } elsif ( $^O eq 'irix' ) {
@@ -192,6 +192,17 @@ sub _get_unix_interface_info {
         #           inet addr:127.0.0.1  Mask:255.0.0.0
         #           UP LOOPBACK RUNNING  MTU:3924  Metric:1
         #
+        # In linux, using /sbin/ip it looks like:
+        # [goldenboy:~] adamb $ ip address
+        # 1: lo:   <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default
+        #     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+        #     inet 127.0.0.1/8 scope host lo
+        #        valid_lft forever preferred_lft forever
+        #     inet6 ::1/128 scope host
+        #        valid_lft forever preferred_lft forever
+        # 2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
+        #     link/ether 9c:b6:54:a5:64:60 brd ff:ff:ff:ff:ff:ff
+        #
         # so the regexen involved here have to deal with the following: 1)
         # there's no ':' after an interface's name in linux 2) in linux, it's
         # "inet addr:127.0.0.1" instead of "inet 127.0.0.1" hence the somewhat
@@ -207,8 +218,7 @@ sub _get_unix_interface_info {
         }
 
         # FIXME: refactor this regex
-        elsif ( ($interface)
-            = ( $line =~ /(^\w+(?:\d)?(?:\.\d+)?(?:\:\d+)?)/x ) )
+        elsif ( ($interface) = ( $line =~ /^(?:\d+\:\s){0,1}(\w+(?:\d)?(?:\.\d+)?(?:\:\d+)?)/x ))
         {
             $line =~ s/\w+\d(\:)?\s+//x;
             $if_info{$interface} = $line;

--- a/t/12-ip.t
+++ b/t/12-ip.t
@@ -1,0 +1,17 @@
+#!perl
+
+use strict;
+use warnings;
+use t::lib::Utils qw/mock_linux_hostip base_tests/;
+
+use Test::More;
+use Sys::HostIP;
+
+if ($^O =~ qr/(MSWin32|cygwin)/x) {
+    plan tests =>  0;
+}
+else {
+    plan tests =>  11;
+    my $hostip = mock_linux_hostip('ip-linux.txt');
+    base_tests($hostip);
+}

--- a/t/data/ip-linux.txt
+++ b/t/data/ip-linux.txt
@@ -1,0 +1,28 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+2: enp0s31f6: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
+    link/ether 18:db:f2:2b:af:26 brd ff:ff:ff:ff:ff:ff
+3: wlp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether f0:d5:bf:51:ad:15 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.2.107/24 brd 192.168.2.255 scope global wlp2s0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::7caf:9455:eb84:50d9/64 scope link
+       valid_lft forever preferred_lft forever
+9: vboxnet0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
+    link/ether 0a:00:27:00:00:00 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.23.1/24 brd 192.168.23.255 scope global vboxnet0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::800:27ff:fe00:0/64 scope link
+       valid_lft forever preferred_lft forever
+10: vboxnet1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    link/ether 0a:00:27:00:00:01 brd ff:ff:ff:ff:ff:ff
+21: tun0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN group default qlen 100
+    link/none
+    inet 10.8.0.2/24 brd 10.8.0.255 scope global tun0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::e057:30b6:8a1b:2fd3/64 scope link flags 800
+       valid_lft forever preferred_lft forever

--- a/t/lib/Utils.pm
+++ b/t/lib/Utils.pm
@@ -12,7 +12,7 @@ use Sys::HostIP qw/ip ips ifconfig interfaces/;
 use Test::More;
 
 @ISA       = qw(Exporter);
-@EXPORT_OK = qw( mock_run_ipconfig mock_win32_hostip base_tests );
+@EXPORT_OK = qw( mock_run_ipconfig mock_win32_hostip mock_linux_hostip base_tests );
 
 sub mock_win32_hostip {
     my $file = shift;
@@ -22,6 +22,22 @@ sub mock_win32_hostip {
         no warnings qw/redefine once/;
         *Sys::HostIP::_run_ipconfig = sub {
             ok( 1, 'Windows was called' );
+            return mock_run_ipconfig($file);
+        };
+    }
+
+    my $hostip = Sys::HostIP->new;
+
+    return $hostip;
+}
+
+sub mock_linux_hostip {
+    my $file = shift;
+
+    {
+        ## no critic qw(TestingAndDebugging::ProhibitNoWarnings)
+        no warnings qw/redefine once/;
+        *Sys::HostIP::_run_ipconfig = sub {
             return mock_run_ipconfig($file);
         };
     }


### PR DESCRIPTION
On linux systems the `ifconfig` command is deprecated and some systems
don't have this command anymore.  In such situations, we should fall
back to using the `ip` command, which in that case *should* exist.

In order to implement this nicely, I used ideas already submitted by
@AdamBalali in pull request #5 and added a test which uses a mock linux
`ip` command output to fake a system where only the `ip` command exists.

@xsawyerx: could you review my code please?  Just in case I've done something silly here, or in case there's something I could do which would be cleaner/clearer.  Many thanks in advance!