### PR TITLE
Fixed 'uninitialized value' warnings reported by CPANTESTERS.

### DIFF
--- a/lib/Sys/HostIP.pm
+++ b/lib/Sys/HostIP.pm
@@ -54,7 +54,12 @@ sub ip {
 
     if ($IS_WIN) {
         my @if_keys = sort keys %{$if_info};
-        return ( $if_info->{ $if_keys[0] } );
+        if ( defined $if_keys[0] ) {
+            return ( $if_info->{ $if_keys[0] } );
+        }
+        else {
+            return '';
+        }
     } else {
         my $lo_found;
 
@@ -73,7 +78,7 @@ sub ip {
         # we get here if loopback is the only active device
         $lo_found and return '127.0.0.1';
 
-        return;
+        return '';
     }
 }
 


### PR DESCRIPTION
Hi @xsawyerx 

Please review the PR.

https://www.cpantesters.org/cpan/report/7b9efe16-6bff-1014-9cac-c182dcff62bf

           Use of uninitialized value $if_keys[0] in hash element at C:\strawberry182\cpan\build\Sys-HostIP-2.110-0\blib\lib/Sys/HostIP.pm line 57.
           Use of uninitialized value $if_keys[0] in hash element at C:\strawberry182\cpan\build\Sys-HostIP-2.110-0\blib\lib/Sys/HostIP.pm line 57.
           Use of uninitialized value $class_ip in concatenation (.) or string at t/lib/Utils.pm line 69.

Many Thanks.
Best Regards,
Mohammad S Anwar